### PR TITLE
html 색인시, 텍스트만 추출하는 기능 개발

### DIFF
--- a/crescent_core_web/src/main/java/com/tistory/devyongsik/admin/CollectionManageServiceImpl.java
+++ b/crescent_core_web/src/main/java/com/tistory/devyongsik/admin/CollectionManageServiceImpl.java
@@ -114,6 +114,7 @@ public class CollectionManageServiceImpl implements CollectionManageService {
 			crescentField.setTermoffset("on".equals(request.getParameter(crescentField.getName()+"-termoffset")) ? true : false);
 			crescentField.setTermposition("on".equals(request.getParameter(crescentField.getName()+"-termposition")) ? true : false);
 			crescentField.setTermvector("on".equals(request.getParameter(crescentField.getName()+"-termvector")) ? true : false);
+			crescentField.setRemoveHtmlTag("on".equals(request.getParameter(crescentField.getName()+"-removeHtmlTag")) ? true : false);
 
 			crescentField.setBoost(Float.parseFloat(StringUtils.defaultString(request.getParameter(crescentField.getName()+"-boost"), "0")));
 			crescentField.setType(StringUtils.defaultString(request.getParameter(crescentField.getName()+"-type"), "STRING"));

--- a/crescent_core_web/src/main/java/com/tistory/devyongsik/admin/IndexFileManageServiceImpl.java
+++ b/crescent_core_web/src/main/java/com/tistory/devyongsik/admin/IndexFileManageServiceImpl.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
@@ -151,7 +152,7 @@ public class IndexFileManageServiceImpl implements IndexFileManageService {
 		}
 		if (topRankingQueue.size() != 0) {
 			topRankingTerms = topRankingQueue.toArray();
-			Arrays.sort(topRankingTerms);
+			Arrays.sort(topRankingTerms, Collections.reverseOrder());
 		}
 		result.put("collectionName", collectionName);
 		result.put("indexName", collection.getIndexingDirectory());

--- a/crescent_core_web/src/main/java/com/tistory/devyongsik/domain/CrescentCollectionField.java
+++ b/crescent_core_web/src/main/java/com/tistory/devyongsik/domain/CrescentCollectionField.java
@@ -38,6 +38,9 @@ public class CrescentCollectionField implements Cloneable {
 	@XStreamAsAttribute
 	private boolean termvector;
 	
+	@XStreamAsAttribute
+	private boolean removeHtmlTag;
+	
 	public String getName() {
 		return name;
 	}
@@ -98,6 +101,12 @@ public class CrescentCollectionField implements Cloneable {
 	public void setTermvector(boolean termvector) {
 		this.termvector = termvector;
 	}
+	public boolean isRemoveHtmlTag() {
+		return removeHtmlTag;
+	}
+	public void setRemoveHtmlTag(boolean removeHtmlTag) {
+		this.removeHtmlTag = removeHtmlTag;
+	}
 	public Occur getOccur() {
 		return must ? Occur.MUST : Occur.SHOULD;
 	}
@@ -122,7 +131,8 @@ public class CrescentCollectionField implements Cloneable {
 				+ ", index=" + index + ", type=" + type + ", analyze="
 				+ analyze + ", termposition=" + termposition + ", termoffset="
 				+ termoffset + ", boost=" + boost + ", must=" + must
-				+ ", termvector=" + termvector + "]";
+				+ ", termvector=" + termvector + ", removeHtmlTag="
+				+ removeHtmlTag + "]";
 	}
 	@Override
 	public Object clone() throws CloneNotSupportedException {

--- a/crescent_core_web/src/main/java/com/tistory/devyongsik/index/LuceneDocumentBuilder.java
+++ b/crescent_core_web/src/main/java/com/tistory/devyongsik/index/LuceneDocumentBuilder.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import net.htmlparser.jericho.Source;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Fieldable;
 import org.slf4j.Logger;
@@ -39,6 +41,11 @@ public class LuceneDocumentBuilder {
 				if(crescentCollectionField == null) {
 					logger.error("해당 collection에 존재하지 않는 필드입니다. [{}]", fieldName);
 					throw new IllegalStateException("해당 collection에 존재하지 않는 필드입니다. ["+fieldName+"]");
+				}
+				
+				if (crescentCollectionField.isRemoveHtmlTag()) {
+					Source source = new Source(value);
+					value = source.getTextExtractor().toString();
 				}
 				
 				Fieldable fieldAble = luceneFieldBuilder.create(fieldsByName.get(fieldName), value);

--- a/crescent_core_web/src/main/resources-local/collection/collections.xml
+++ b/crescent_core_web/src/main/resources-local/collection/collections.xml
@@ -14,7 +14,7 @@
     <searcherReloadScheduleMin>50</searcherReloadScheduleMin>
     <!-- indexingDirectory>/data1/lucene_index/sample</indexingDirectory -->
     <fields>
-      <field name="board_id" store="true" index="true" type="Long" analyze="false" termposition="false" termoffset="false" boost="0.0" must="false" termvector="false"/>
+      <field name="board_id" store="true" index="true" type="LONG" analyze="false" termposition="false" termoffset="false" boost="0.0" must="false" termvector="false"/>
       <field name="title" store="true" index="true" type="STRING" analyze="true" termposition="false" termoffset="false" boost="2.0" must="false" termvector="false"/>
       <field name="dscr" store="true" index="true" type="STRING" analyze="true" termposition="true" termoffset="true" boost="0.0" must="true" termvector="true"/>
       <field name="creuser" store="true" index="true" type="STRING" analyze="false" termposition="false" termoffset="false" boost="0.0" must="false" termvector="false"/>

--- a/crescent_core_web/webapp/jsp/admin/collectionManageMain.jsp
+++ b/crescent_core_web/webapp/jsp/admin/collectionManageMain.jsp
@@ -20,6 +20,7 @@
 		clonedRow.find('#fieldName').attr('disabled', false);
 		clonedRow.find('#defaultSearchField').attr('checked', false);
 		clonedRow.find('#sortField').attr('checked', false);
+		clonedRow.find('#removeHtmlTag').attr('checked', false);
 		clonedRow.find('#store').attr('checked', false);
 		clonedRow.find('#index').attr('checked', false);
 		clonedRow.find('#analyze').attr('checked', false);
@@ -54,7 +55,6 @@
 				isValid = false;
 				return;
 			}
-			//console.log("fieldName : " + fieldName);
 			
 			$(this).find('input,select').each(function() {
 				var id = $(this).attr('id');
@@ -185,6 +185,7 @@
               <th>termvector</th>
               <th>DefaultSearchField</th>
               <th>SortField</th>
+              <th>removeHtmlTag</th>
             </tr>
           </thead>
           <tbody>
@@ -224,6 +225,7 @@
 	              	</c:if>
 	              </c:forEach>
 	              <td style="text-align: center;"><input type="checkbox" id="sortField" name="sortField" <c:if test="${isSortField}">checked</c:if>></td>
+	              <td style="text-align: center;"><input type="checkbox" id="removeHtmlTag" name="removeHtmlTag" <c:choose><c:when test='${field.type eq "LONG"}'>disabled</c:when><c:when test='${field.removeHtmlTag == true}'>checked</c:when></c:choose>></td>
 	            </tr>
           	</c:forEach>
           </tbody>

--- a/crescent_core_web/webapp/jsp/admin/indexFileManageMain.jsp
+++ b/crescent_core_web/webapp/jsp/admin/indexFileManageMain.jsp
@@ -1,7 +1,7 @@
 <%@page language="java" contentType="text/html; charset=utf-8"
 	pageEncoding="utf-8"%>
-<%@ taglib uri="http://java.sun.com/jstl/core_rt" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"  %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <c:set var="collection" value="${RESULT.collectionName }" />
 <c:set var="index_name" value="${RESULT.indexName }" />
 <c:set var="num_field" value="${RESULT.numOfField }" />
@@ -184,13 +184,12 @@
 								</tr>
 							</thead>
 							<tbody>
-								<c:forEach begin="1" end="${top_ranking_count }" step="1" var="i">
+								<c:forEach items="${top_ranking }" var="top_item" varStatus="index">
 								<tr>
-									<td>${i }</td>
-									<td>${top_ranking[top_ranking_count-i].count }</td>
-									<td>${top_ranking[top_ranking_count-i].field }</td>
-									<td>${top_ranking[top_ranking_count-i].text }</td>
-									
+									<td>${index.count }</td>
+									<td>${top_item.count }</td>
+									<td>${top_item.field }</td>
+									<td>${top_item.text }</td>
 								</tr>
 								</c:forEach>
 							</tbody>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,11 @@
       <artifactId>hsqldb</artifactId>
       <version>2.2.9</version>
     </dependency>        
+	<dependency>
+		<groupId>net.htmlparser.jericho</groupId>
+		<artifactId>jericho-html</artifactId>
+		<version>3.0</version>
+	</dependency>
   </dependencies>
   
   <build>


### PR DESCRIPTION
https://github.com/need4spd/crescent/issues/87 과  TopRanking 수장하였습니다.

admin page에서 Collection에 맨 끝에 옵션 추가 하였습니다.
테스트한 색인 데이타는 

``` json
{"command":"add", "indexingType":"bulk","documentList":[{"title":"<html><head></head><body><a href='#'>강한구 </a><table><tr>Crescent is so cooool cooool cooool</tr></table></body></html>","dscr":"텍스트 입니다0","creuser":"creuser0","board_id":"0"},{"title":"<html><head></head><body><a href='#'>coool </a><table><tr>cooool cooool cooool</tr></table></body></html>","dscr":"텍스트 입니다0","creuser":"creuser0","board_id":"0"}]}
```

입니다.

보여주는 기능 개발이 대부분이어서 test unit은 만들지 않았습니다.;; 
웹은 어떻게 테스트를 할지 모르겠네요
